### PR TITLE
Fixed some issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
 RUN mkdir /tmp/zookeeper
 WORKDIR /tmp/zookeeper
 RUN git clone https://github.com/apache/zookeeper.git .
-RUN git checkout release-3.5.1-rc2
+RUN git checkout release-3.5.1
 RUN ant jar
 ADD zoo.cfg /tmp/zookeeper/conf/
 ADD zk-init.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /tmp/zookeeper
 RUN git clone https://github.com/apache/zookeeper.git .
 RUN git checkout release-3.5.1-rc2
 RUN ant jar
-RUN cp /tmp/zookeeper/conf/zoo_sample.cfg /tmp/zookeeper/conf/zoo.cfg
-RUN echo "standaloneEnabled=false" >> /tmp/zookeeper/conf/zoo.cfg
-RUN	echo "dynamicConfigFile=/tmp/zookeeper/conf/zoo.cfg.dynamic" >> /tmp/zookeeper/conf/zoo.cfg
+ADD zoo.cfg /tmp/zookeeper/conf/
 ADD zk-init.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/zk-init.sh"]

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 #Zookeeper
 
-This Docker image contains Zookeeper 3.5.1-rc2 which features dynamic host reconfiguration. Upon start, it attempts to join an existing cluster.
+This Docker image contains Zookeeper 3.5.1 which features dynamic host reconfiguration. Upon start, it attempts to join an existing cluster.
 
 The syntax to start a container is like this:
 
-  `docker run --net host --name [name] containersol/zookeeper [id] [ip]`
+  `docker run -p 2181:2181 -p 2888:2888 -p 3888:3888 --name [name] containersol/zookeeper [ip]`
   
 where 
-  - `id` = id of the zookeeper node (known internally as myid)
   - `ip` = ip address of a node of the existing cluster
   
-The `id` is mandatory, the `ip` is optional.
+You don't need to supply `ip` for the first (or only) node in a cluster.
 
-The `--net host` is needed for zookeepers on different hosts to be able to contact each other.

--- a/zk-init.sh
+++ b/zk-init.sh
@@ -1,38 +1,24 @@
 #!/bin/bash
 
 ZK=$1
-MYID=1
 IPADDRESS=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print \$2}' | cut -d / -f 1`
+MYID=$(echo $IPADDRESS | sed 's/\.//g')
 
 cd /tmp/zookeeper
 if [ -n "$ZK" ] 
 then
-  output=`./bin/zkCli.sh -server $ZK:2181 get /zookeeper/config | grep ^server` 
-  
-  # extract all the zk-ids from the output
-  declare -a id_list=()
-  while read x;
-  do
-    id_list+=(`echo $x | cut -d"=" -f1 | cut -d"." -f2`)
-  done <<<$(output)
-  sorted_id_list=( $(
-    for el in "${id_list[@]}"
-    do  
-      echo "$el"
-    done | sort -n) )
-  
-  # get the next increasing number from the sequence
-  MYID=$((${sorted_id_list[${#sorted_id_list[@]}-1]}+1))
-  echo $output >> /tmp/zookeeper/conf/zoo.cfg.dynamic
-  echo "server.$MYID=$IPADDRESS:2888:3888:observer;2181" >> /tmp/zookeeper/conf/zoo.cfg.dynamic
-  cp /tmp/zookeeper/conf/zoo.cfg.dynamic /tmp/zookeeper/conf/zoo.cfg.dynamic.org
+  ./bin/zkCli.sh -server $ZK:2181 get /zookeeper/config | grep ^server >> /tmp/zookeeper/conf/zoo.cfg
+  echo "server.$MYID=$IPADDRESS:2888:3888:observer;2181" >> /tmp/zookeeper/conf/zoo.cfg
+  cp /tmp/zookeeper/conf/zoo.cfg /tmp/zookeeper/conf/zoo.cfg.org
   /tmp/zookeeper/bin/zkServer-initialize.sh --force --myid=$MYID
   ZOO_LOG_DIR=/var/log ZOO_LOG4J_PROP='INFO,CONSOLE,ROLLINGFILE' /tmp/zookeeper/bin/zkServer.sh start
+  sleep 10
   /tmp/zookeeper/bin/zkCli.sh -server $ZK:2181 reconfig -add "server.$MYID=$IPADDRESS:2888:3888:participant;2181"
-  /tmp/zookeeper/bin/zkServer.sh stop
-  ZOO_LOG_DIR=/var/log ZOO_LOG4J_PROP='INFO,CONSOLE,ROLLINGFILE' /tmp/zookeeper/bin/zkServer.sh start-foreground
+  while true; do sleep 10000; done # block forever
+  #/tmp/zookeeper/bin/zkServer.sh stop
+  #ZOO_LOG_DIR=/var/log ZOO_LOG4J_PROP='INFO,CONSOLE,ROLLINGFILE' /tmp/zookeeper/bin/zkServer.sh start-foreground
 else
-  echo "server.$MYID=$IPADDRESS:2888:3888;2181" >> /tmp/zookeeper/conf/zoo.cfg.dynamic
+  echo "server.$MYID=$IPADDRESS:2888:3888;2181" >> /tmp/zookeeper/conf/zoo.cfg
   /tmp/zookeeper/bin/zkServer-initialize.sh --force --myid=$MYID
   ZOO_LOG_DIR=/var/log ZOO_LOG4J_PROP='INFO,CONSOLE,ROLLINGFILE' /tmp/zookeeper/bin/zkServer.sh start-foreground
 fi

--- a/zk-init.sh
+++ b/zk-init.sh
@@ -15,8 +15,6 @@ then
   sleep 10
   /tmp/zookeeper/bin/zkCli.sh -server $ZK:2181 reconfig -add "server.$MYID=$IPADDRESS:2888:3888:participant;2181"
   while true; do sleep 10000; done # block forever
-  #/tmp/zookeeper/bin/zkServer.sh stop
-  #ZOO_LOG_DIR=/var/log ZOO_LOG4J_PROP='INFO,CONSOLE,ROLLINGFILE' /tmp/zookeeper/bin/zkServer.sh start-foreground
 else
   echo "server.$MYID=$IPADDRESS:2888:3888;2181" >> /tmp/zookeeper/conf/zoo.cfg
   /tmp/zookeeper/bin/zkServer-initialize.sh --force --myid=$MYID

--- a/zoo.cfg
+++ b/zoo.cfg
@@ -1,0 +1,6 @@
+tickTime=2000
+dataDir=/tmp/zookeeper
+initLimit=5
+syncLimit=2
+standaloneEnabled=false
+


### PR DESCRIPTION
Made a few changes and bug fixes:
- If you try to bring a container into a cluster that already has 2 or more nodes, Zookeeper would fail to start.  This was because the output from zkCli was getting concatenated on to a single line.  Fixed by piping output directly to zoo.cfg
- Simplified configuration by taking advantage of the fact that Zookeeper 3.5.1 will automatically split a single `zoo.cfg` configuration file into static and dynamic portions on startup
- Use our own config file instead of copying the sample
- Up Zookeeper version to 3.5.1 release.
- Updated README to reflect changes
